### PR TITLE
Feat create preference

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -1,8 +1,35 @@
 # frozen_string_literal: true
 
 class PreferencesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_preference, only: %i[show edit update destroy]
+
   def index
     @preferences = current_user.preferences
     @pagy, @records = pagy(@preferences)
+  end
+
+  def new
+    @preference = Preference.new
+  end
+
+  def create
+    @preference = current_user.preferences.build(preference_params)
+
+    if @preference.save!
+      redirect_to preference_path(@preference), notice: t('views.preferences.create_success')
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def preference_params
+    params.require(:preference).permit(:name, :description, :restriction)
+  end
+
+  def set_preference
+    @preference = current_user.preferences.find(params[:id])
   end
 end

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: preferences
+#
+#  id          :bigint           not null, primary key
+#  name        :string           not null
+#  description :text             not null
+#  restriction :boolean          default(FALSE), not null
+#  user_id     :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_preferences_on_user_id  (user_id)
+#
+class Preference < ApplicationRecord
+  MAX_PREFERENCES = 5
+  belongs_to :user
+
+  validates :name, presence: true
+  validates :description, presence: true
+  validates :restriction, inclusion: { in: [true, false] }
+end

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -20,5 +20,4 @@ class Preference < ApplicationRecord
 
   validates :name, presence: true
   validates :description, presence: true
-  validates :restriction, inclusion: { in: [true, false] }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,6 @@
 #  invited_by_type        :string
 #  invited_by_id          :bigint
 #  invitations_count      :integer          default(0)
-#  preferences_enabled    :boolean          default(TRUE), not null
 #
 # Indexes
 #
@@ -54,7 +53,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, on: :update
 
   attribute :impersonated_by, :integer
-
+  has_many :preferences, dependent: :destroy
   before_validation :init_uid
 
   RANSACK_ATTRIBUTES = %w[id email first_name last_name username sign_in_count current_sign_in_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
       - Description
       - Restriction
       create_preference: Create Preference
+      create_success: Preference successfully created.
       description: Description
       edit:
         description: ''

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   end
 
   resources :users
-  resources :preferences, only: %i[index]
+  resources :preferences
   resources :recipes, only: %i[index]
 
   namespace :api do

--- a/db/migrate/20241010133456_create_preferences.rb
+++ b/db/migrate/20241010133456_create_preferences.rb
@@ -1,0 +1,12 @@
+class CreatePreferences < ActiveRecord::Migration[7.1]
+  def change
+    create_table :preferences do |t|
+      t.string :name, null: false
+      t.text :description, null:false
+      t.boolean :restriction, null:false, default: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_29_191410) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_10_133456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -102,16 +102,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_29_191410) do
     t.index ["user_id"], name: "index_preferences_on_user_id"
   end
 
-  create_table "recipes", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "description", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "ingredients", default: "", null: false
-    t.index ["user_id"], name: "index_recipes_on_user_id"
-  end
-
   create_table "settings", force: :cascade do |t|
     t.string "key", null: false
     t.string "value"
@@ -147,7 +137,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_29_191410) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
-    t.boolean "preferences_enabled", default: true, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
@@ -158,5 +147,4 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_29_191410) do
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "preferences", "users"
-  add_foreign_key "recipes", "users"
 end

--- a/spec/factories/preferences.rb
+++ b/spec/factories/preferences.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: preferences
+#
+#  id          :bigint           not null, primary key
+#  name        :string           not null
+#  description :text             not null
+#  restriction :boolean          default(FALSE), not null
+#  user_id     :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_preferences_on_user_id  (user_id)
+#
+FactoryBot.define do
+  factory :preference do
+    name { "MyString" }
+    description { "MyText" }
+    restriction { false }
+    user { nil }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,7 +31,6 @@
 #  invited_by_type        :string
 #  invited_by_id          :bigint
 #  invitations_count      :integer          default(0)
-#  preferences_enabled    :boolean          default(TRUE), not null
 #
 # Indexes
 #

--- a/spec/models/preference_spec.rb
+++ b/spec/models/preference_spec.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: preferences
+#
+#  id          :bigint           not null, primary key
+#  name        :string           not null
+#  description :text             not null
+#  restriction :boolean          default(FALSE), not null
+#  user_id     :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_preferences_on_user_id  (user_id)
+#
+require 'rails_helper'
+
+RSpec.describe Preference, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/preference_spec.rb
+++ b/spec/models/preference_spec.rb
@@ -16,6 +16,27 @@
 #
 require 'rails_helper'
 
-RSpec.describe Preference, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Preference  do
+  describe 'validations' do
+    subject { build(:preference) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:description) }
+  end
+
+  context 'when was created with regular login' do
+    let!(:user) { create(:user) }
+    let!(:preference) { create(:preference, user:) }
+    let(:name) { preference.name }
+    let(:description) { preference.description }
+    let(:restriction) { preference.restriction }
+
+    it 'returns the correct attributes' do
+      expect(name).to eq(preference.name)
+      expect(description).to eq(preference.description)
+      expect(restriction).to eq(preference.restriction)
+    end
+
+    it { is_expected.to belong_to(:user) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,7 +31,6 @@
 #  invited_by_type        :string
 #  invited_by_id          :bigint
 #  invitations_count      :integer          default(0)
-#  preferences_enabled    :boolean          default(TRUE), not null
 #
 # Indexes
 #


### PR DESCRIPTION
#### Board:
* [Ticket #01](https://www.notion.so/1-Create-Preference-10bd92de40328092bf79e33eb0808904)
---
#### Description:
This PR implements the "Create Preference" feature, allowing users to create a new preference with the attributes: name (string), description (text), and restriction (boolean).