### PR TITLE
Feat show preference details

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -1,8 +1,37 @@
 # frozen_string_literal: true
 
 class PreferencesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_preference, only: %i[edit update show destroy]
+
   def index
     @preferences = current_user.preferences
     @pagy, @records = pagy(@preferences)
+  end
+
+  def show; end
+
+  def new
+    @preference = Preference.new
+  end
+
+  def create
+    @preference = current_user.preferences.build(preference_params)
+
+    if @preference.save!
+      redirect_to preference_path(@preference), notice: t('views.preferences.create_success')
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def preference_params
+    params.require(:preference).permit(:name, :description, :restriction)
+  end
+
+  def set_preference
+    @preference = current_user.preferences.find(params[:id])
   end
 end

--- a/spec/features/preferences/show_preference_spec.rb
+++ b/spec/features/preferences/show_preference_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show preference', :js do
+  let(:user) { create(:user) }
+  let!(:preference) { create(:preference, user:) }
+
+  before do
+    sign_in user
+    visit preferences_path
+    show_first_preference
+  end
+
+  describe '#show' do
+    context 'when clicking on some preference' do
+      it 'show the data the requested preference' do
+        within '#panel' do
+          expect(page).to have_content('Name')
+          expect(page).to have_content('Description')
+          expect(page).to have_content('Restriction')
+        end
+      end
+    end
+  end
+
+  def show_first_preference
+    within all('tbody tr').first do
+      click_on 'Show'
+    end
+  end
+end


### PR DESCRIPTION
#### Board:
* [Ticket #02](https://rootstrap.notion.site/2-View-Preference-Details-b9e43483d474432cb94e4c1a32e492c4)
---
#### Description:
This PR introduces the ability to view the details of a specific preference, including its name, description, and restriction attributes.