### PR TITLE
Feat update and destroy preference

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -5,4 +5,44 @@ class PreferencesController < ApplicationController
     @preferences = current_user.preferences
     @pagy, @records = pagy(@preferences)
   end
+
+  def new
+    @preference = Preference.new
+  end
+
+  def create
+    @preference = current_user.preferences.build(preference_params)
+
+    if @preference.save!
+      redirect_to preference_path(@preference), notice: t('views.preferences.create_success')
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @preference.update!(preference_params)
+      redirect_to preference_path(@preference), notice: t('views.preferences.update_success')
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @preference.destroy!
+      redirect_to preferences_path, notice: t('views.preferences.destroy_success')
+    else
+      redirect_to preferences_path, alert: t('views.preferences.destroy_failure')
+    end
+  end
+
+  private
+
+  def preference_params
+    params.require(:preference).permit(:name, :description, :restriction)
+  end
+
+  def set_preference
+    @preference = current_user.preferences.find(params[:id])
+  end
 end

--- a/spec/features/preferences/destroy_preference_spec.rb
+++ b/spec/features/preferences/destroy_preference_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Destroy preference' do
+  let!(:user) { create(:user) }
+  let!(:preference) { create(:preference, user:) }
+
+  before do
+    sign_in user
+    visit preferences_path
+  end
+
+  describe '#destroy' do
+    it 'destroys the requested preference' do
+      destroy_first_preference
+      expect(page).to have_content('Preference successfully removed.')
+      expect(page).to have_no_content(preference.name)
+    end
+  end
+
+  def destroy_first_preference
+    within all('tbody tr').first do
+      click_on 'Remove'
+    end
+  end
+end

--- a/spec/features/preferences/edit_preference_spec.rb
+++ b/spec/features/preferences/edit_preference_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Edit preference' do
+  let!(:user) { create(:user) }
+  let!(:preference) { create(:preference, user:) }
+
+  before do
+    sign_in user
+    visit preferences_path
+  end
+
+  describe '#update' do
+    context 'with valid attributes' do
+      it 'updates the requested preference' do
+        edit_first_preference('New preference')
+        expect(page).to have_content('Preference successfully updated.')
+        expect(find('input[name="preference[name]"]').value).to eq('New preference') # Css Selector was needed to target field.
+        expect(find('input[name="preference[description]"]').value).to eq('Test description') # Css Selector was needed to target field.
+        expect(preference.reload.restriction).to be(true)
+      end
+    end
+
+    context 'with invalid attributes' do
+      it 'renders the edit template with error messages' do
+        edit_first_preference('')
+        expect(page).to have_text("Name can't be blank", wait: 5)
+      end
+    end
+  end
+
+  def edit_first_preference(name)
+    within all('tbody tr').first do
+      click_on 'Edit'
+    end
+    fill_in 'Name', with: name
+    fill_in 'Description', with: 'Test description'
+    check 'Restriction'
+    click_on 'Update Preference'
+  end
+end


### PR DESCRIPTION
#### Board:
* [Ticket #03](https://rootstrap.notion.site/3-Edit-Preference-177e88d8333e485f952b1696bc404a77)
* [Ticket #04](https://rootstrap.notion.site/4-Delete-Preference-89416d5c995042389d703bcbfccb9be8)
---
#### Description:
This PR adds functionality for users to edit and delete existing preferences. Users can update preference details (name, description, and restriction) or remove a preference from their account.